### PR TITLE
Add script to delete older entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@
 
   Note: If you want to repeat the process, run `bin/db/bobby_drop_tables` inside the `heartbeat_1` container before starting again from step 3.
 
+# Deleting older entries
+
+The script `bin/tasks/delete_old_calls.rb` was created to delete old entries. The main purpose is associate it with a
+cron-job or any other kind of scheduler. This is needed because Postgres does not support TTL natively.
+
+To run it:
+```
+    ruby bin/tasks/delete_old_calls.rb DAYS
+```
+It will delete all entries older than the given `DAYS`
+
+_NOTE: The scripts needs the `POSTGRES_URL` environment variable. You might prefer to run it in your (development) containers or in your deployment environment._  
+_DOCKER: `docker-compose run heartbeat ruby bin/tasks/delete_old_calls.rb DAYS`_  
+
 # TODO
 
 - [X] Configure threads for:
@@ -49,6 +63,7 @@
 - [ ] Ensure we can cleanup after ourselves:
   - [ ] Script to unbind our RabbitMQ queue in DEV environments
   - [ ] Use bunny gem to achieve operational scripts
+  - [ ] Implement authenticated HTTP API for deleting older calls
 
 - [ ] Finish writting the readme file
   - [X] Explain dev setup

--- a/bin/tasks/delete_old_calls.rb
+++ b/bin/tasks/delete_old_calls.rb
@@ -1,0 +1,14 @@
+
+require 'logger'
+require_relative '../../lib/interactors/delete_old_calls'
+
+logger = Logger.new($stdout)
+
+days = Integer ARGV.first
+
+
+logger.info("Preparing to delete calls older than #{days} days.")
+
+deleted = delete_old_calls days
+
+logger.info("Deleted #{deleted} calls.")

--- a/lib/interactors/delete_old_calls.rb
+++ b/lib/interactors/delete_old_calls.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'logger'
+require_relative '../repositories/calls.rb'
+
+def delete_old_calls(days)
+  logger = Logger.new($stdout)
+  logger.info("Deleting calls older than #{days} days.")
+
+  calls = Calls.new
+  calls.delete_old_calls(days: days)
+end

--- a/lib/repositories/calls.rb
+++ b/lib/repositories/calls.rb
@@ -58,4 +58,10 @@ class Calls
       )
     end
   end
+
+  def delete_old_calls(days:)
+    @db.transaction do
+      @db[:calls].where { created_at < DateTime.now - days }.delete
+    end
+  end
 end


### PR DESCRIPTION
A script to delete older entries was created.

The purpose of the task was to create a TTL for the
database entries. Since Postgres does not support it there
were two alternatives:

1. Triggers:
	- This would probably require a trigger on insert, which
	  I feel is not only innefficient but also overkill.
2. A script associated to a sheduler job:
	- Easier to write and iterate.
	- But the deployment environment may not running scripts
 	  or have a scheduler.

The latter was chosen for ease of development. Both Heroku
and MEza suppor scheduling of jobs, so we have no practical
restrictions.

Part of the work of this job was make with the help of the
research made by Valter Nepomuceno on the context of
TEL-614 [PR](https://github.com/Talkdesk/legacy-translation/pull/54)